### PR TITLE
Add role-based demo with 100ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Role Based Participation
+
+This demo shows how you can integrate [100ms](https://www.100ms.live/) with React
+while supporting multiple roles in the room. The available roles are Judge,
+Speaker, Moderator and Audience. Specific controls are rendered depending on the
+selected role. For example only Judges see the **Score Speaker** button and only
+Speakers see the **Speak** button.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,18 @@
   color: #61dafb;
 }
 
+.role-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+}
+
+.role-controls {
+  margin-bottom: 1rem;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,33 @@
-import './App.css';
-import { HMSPrebuilt } from '@100mslive/roomkit-react';
+import "./App.css";
+import { useState } from "react";
+import { HMSPrebuilt } from "@100mslive/roomkit-react";
+import RoleControls from "./RoleControls";
+
 function App() {
+  const [role, setRole] = useState("");
+
+  if (!role) {
+    return (
+      <div className="role-selection">
+        <h2>Select Your Role</h2>
+        <select
+          aria-label="Select Role"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        >
+          <option value="">Select...</option>
+          <option value="judge">Judge</option>
+          <option value="speaker">Speaker</option>
+          <option value="moderator">Moderator</option>
+          <option value="audience">Audience</option>
+        </select>
+      </div>
+    );
+  }
+
   return (
     <div style={{ height: "100vh" }}>
+      <RoleControls role={role} />
       <HMSPrebuilt roomCode="aue-gnov-bkt" />
     </div>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
-test('renders learn react link', () => {
+test('allows selecting role and shows controls', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const select = screen.getByLabelText(/select role/i);
+  expect(select).toBeInTheDocument();
+  await userEvent.selectOptions(select, 'judge');
+  const button = screen.getByText(/score speaker/i);
+  expect(button).toBeInTheDocument();
 });

--- a/src/RoleControls.js
+++ b/src/RoleControls.js
@@ -1,0 +1,28 @@
+import React from "react";
+
+function RoleControls({ role }) {
+  if (role === "judge") {
+    return (
+      <div className="role-controls">
+        <button>Score Speaker</button>
+      </div>
+    );
+  }
+  if (role === "speaker") {
+    return (
+      <div className="role-controls">
+        <button>Speak</button>
+      </div>
+    );
+  }
+  if (role === "moderator") {
+    return (
+      <div className="role-controls">
+        <button>Moderate Room</button>
+      </div>
+    );
+  }
+  return null;
+}
+
+export default RoleControls;


### PR DESCRIPTION
## Summary
- demonstrate a basic role-based experience using 100ms prebuilt
- add RoleControls component
- update App.css with simple styles
- update README to describe roles
- test role selection logic

## Testing
- `npm test -- -u --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68428d491678832ba7d61b5ff95b9d9b