### PR TITLE
Add 100ms backend sample and token based join

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+HMS_ACCESS_KEY=your_access_key_here
+HMS_SECRET=your_secret_key_here

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# Firely 100ms Demo
+
+This example shows how to integrate the [100ms](https://100ms.live) video SDK
+with a React frontend and a small Node backend. The backend creates rooms using
+the 100ms Management API and generates JWT tokens which the React app uses to
+join a room.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your `HMS_ACCESS_KEY` and
+   `HMS_SECRET` from the 100ms dashboard.
+2. Install dependencies with `npm install`.
+3. Start the backend with `npm run server` and the React app with `npm start`.
+
+The React app fetches a token from `http://localhost:3001/token` and joins the
+specified room using the `@100mslive/react-sdk`.
+
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+const app = express();
+app.use(express.json());
+
+const HMS_BASE_URL = 'https://api.100ms.live/v2';
+const { HMS_ACCESS_KEY, HMS_SECRET } = process.env;
+
+async function createRoom(name) {
+  const res = await fetch(`${HMS_BASE_URL}/rooms`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${HMS_ACCESS_KEY}:${HMS_SECRET}`
+    },
+    body: JSON.stringify({ name })
+  });
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(errorText);
+  }
+  return res.json();
+}
+
+function generateToken({room_id, user_id, role}) {
+  const payload = {
+    access_key: HMS_ACCESS_KEY,
+    room_id,
+    user_id,
+    role,
+    type: 'app',
+    version: 2,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 3600
+  };
+  return jwt.sign(payload, HMS_SECRET);
+}
+
+app.post('/create-room', async (req, res) => {
+  try {
+    const { name } = req.body;
+    const room = await createRoom(name);
+    res.json(room);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/token', (req, res) => {
+  const { room_id, user_id, role } = req.body;
+  try {
+    const token = generateToken({ room_id, user_id, role });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Backend running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@100mslive/roomkit-react": "^0.3.35",
+    "@100mslive/react-sdk": "^0.9.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -13,10 +14,15 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
+    "express": "^4.18.2",
+    "dotenv": "^16.3.1",
+    "jsonwebtoken": "^9.0.0",
+    "node-fetch": "^2.6.12",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",
+    "server": "node backend/server.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,46 @@
 import './App.css';
-import { HMSPrebuilt } from '@100mslive/roomkit-react';
-function App() {
+import React, { useEffect, useState } from 'react';
+import { HMSRoomProvider, useHMSActions, useHMSStore, selectPeers } from '@100mslive/react-sdk';
+
+function Conference() {
+  const hmsActions = useHMSActions();
+  const peers = useHMSStore(selectPeers);
+  const [joined, setJoined] = useState(false);
+
+  const joinRoom = async () => {
+    const res = await fetch('http://localhost:3001/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        room_id: 'YOUR_ROOM_ID',
+        user_id: 'user-' + Math.floor(Math.random() * 1000),
+        role: 'host'
+      })
+    });
+    const data = await res.json();
+    await hmsActions.join({ userName: 'React User', authToken: data.token });
+    setJoined(true);
+  };
+
+  useEffect(() => {
+    // Auto join for demo purposes
+    if (!joined) {
+      joinRoom();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
-    <div style={{ height: "100vh" }}>
-      <HMSPrebuilt roomCode="aue-gnov-bkt" />
+    <div className="App">
+      {!joined && <p>Joining...</p>}
+      {joined && peers.map(peer => (<div key={peer.id}>{peer.name}</div>))}
     </div>
   );
 }
 
-export default App;
+export default function App() {
+  return (
+    <HMSRoomProvider>
+      <Conference />
+    </HMSRoomProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add Node backend to create rooms and generate JWT tokens
- allow React app to join using `@100mslive/react-sdk`
- provide environment sample and setup instructions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68429af4c728832bad88c7587e874002