### PR TITLE
Add role-based participation UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,15 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.role-selection {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  margin-top: 2rem;
 }
 
-.App-link {
-  color: #61dafb;
+.scoreboard {
+  margin-top: 1rem;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.moderator-panel {
+  margin-top: 1rem;
+  font-weight: bold;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,74 @@
 import './App.css';
+import { useState } from 'react';
 import { HMSPrebuilt } from '@100mslive/roomkit-react';
-function App() {
+
+const ROLES = ['Judge', 'Speaker', 'Moderator', 'Audience'];
+
+function RoleSelection({ onSelect }) {
   return (
-    <div style={{ height: "100vh" }}>
-      <HMSPrebuilt roomCode="aue-gnov-bkt" />
+    <div className="role-selection">
+      <h2>Select your role</h2>
+      <select data-testid="role-select" defaultValue="" onChange={(e) => onSelect(e.target.value)}>
+        <option value="" disabled>Choose role</option>
+        {ROLES.map(r => <option key={r} value={r}>{r}</option>)}
+      </select>
     </div>
   );
+}
+
+function ScoreInput({ onAdd }) {
+  const [name, setName] = useState('');
+  const [score, setScore] = useState('');
+  const submit = () => {
+    if (name && score) {
+      onAdd(name, score);
+      setName('');
+      setScore('');
+    }
+  };
+  return (
+    <div>
+      <input value={name} onChange={e => setName(e.target.value)} placeholder="Speaker name" />
+      <input value={score} onChange={e => setScore(e.target.value)} placeholder="Score" type="number" />
+      <button onClick={submit}>Add Score</button>
+    </div>
+  );
+}
+
+function Room({ role }) {
+  const [speaking, setSpeaking] = useState(false);
+  const [scores, setScores] = useState({});
+  const addScore = (name, score) => setScores({ ...scores, [name]: score });
+  return (
+    <div style={{ height: '100vh' }}>
+      <HMSPrebuilt roomCode="aue-gnov-bkt" />
+      {role === 'Speaker' && (
+        <button onClick={() => setSpeaking(!speaking)} data-testid="speak-btn">
+          {speaking ? 'Stop Speaking' : 'Speak'}
+        </button>
+      )}
+      {role === 'Judge' && (
+        <div className="scoreboard">
+          <h3>Scoreboard</h3>
+          <ScoreInput onAdd={addScore} />
+          <ul>
+            {Object.entries(scores).map(([name, score]) => (
+              <li key={name}>{name}: {score}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {role === 'Moderator' && <p className="moderator-panel">Moderator controls enabled</p>}
+    </div>
+  );
+}
+
+function App() {
+  const [role, setRole] = useState('');
+  if (!role) {
+    return <RoleSelection onSelect={setRole} />;
+  }
+  return <Room role={role} />;
 }
 
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders role selection', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const select = screen.getByTestId('role-select');
+  expect(select).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add role selection and conditional features for judges, speakers and moderators
- style new components with CSS
- update unit test for role selection

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843c9e05584832b8bd646f73210c962