### PR TITLE
Add custom 100ms demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
+# Custom 100ms Setup with Role Based Permissions
+
+This project demonstrates how to create rooms on demand using the 100ms
+Management API, generate JWT tokens on a small Express backend and join the
+room from a React client using the 100ms React SDK. It also illustrates four
+custom roles (**Judge**, **Speaker**, **Moderator**, and **Audience**) with
+simple permission controls.
+
+## Running the example
+
+1. In the `server` folder create a `.env` file with your API keys:
+
+   ```bash
+   CLIENT_ID=your_management_client_id
+   CLIENT_SECRET=your_management_client_secret
+   APP_ACCESS_KEY=your_app_access_key
+   APP_SECRET=your_app_secret
+   ```
+
+2. Start the backend server:
+
+   ```bash
+   node server/index.js
+   ```
+
+3. From another terminal start the React app:
+
+   ```bash
+   npm start
+   ```
+
+Selecting a role and clicking **Join Room** will create a room, generate a JWT
+for the chosen role and connect using the 100ms SDK.
+
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@100mslive/roomkit-react": "^0.3.35",
+    "@100mslive/hms-video-react": "^1.7.0",
+    "axios": "^1.6.7",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,39 @@
+import express from 'express';
+import axios from 'axios';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { CLIENT_ID, CLIENT_SECRET, APP_ACCESS_KEY, APP_SECRET } = process.env;
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/create-room', async (req, res) => {
+  const { role = 'audience', username = 'anonymous' } = req.body;
+  try {
+    const roomResponse = await axios.post(
+      'https://api.100ms.live/v2/rooms',
+      { name: `room-${Date.now()}` },
+      { headers: { 'X-CLIENT-ID': CLIENT_ID, 'X-CLIENT-SECRET': CLIENT_SECRET } }
+    );
+    const roomId = roomResponse.data.id;
+    const payload = {
+      room_id: roomId,
+      user_id: username,
+      role,
+    };
+    const token = jwt.sign(payload, APP_SECRET, {
+      expiresIn: '1h',
+      issuer: APP_ACCESS_KEY,
+    });
+    res.json({ roomId, token });
+  } catch (err) {
+    console.error(err.response?.data || err.message);
+    res.status(500).json({ error: 'Failed to create room' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hms-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.6.7",
+    "dotenv": "^16.3.1",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.1"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,10 @@
   color: #61dafb;
 }
 
+.join-panel {
+  margin-top: 2rem;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,69 @@
 import './App.css';
-import { HMSPrebuilt } from '@100mslive/roomkit-react';
-function App() {
+import axios from 'axios';
+import { useState } from 'react';
+import {
+  HMSRoomProvider,
+  useHMSActions,
+  useHMSStore,
+  selectIsConnected,
+  selectLocalPeer,
+} from '@100mslive/hms-video-react';
+
+function RoleControls() {
+  const localPeer = useHMSStore(selectLocalPeer);
+  const hmsActions = useHMSActions();
+  if (!localPeer) return null;
+  const { roleName } = localPeer;
+
   return (
-    <div style={{ height: "100vh" }}>
-      <HMSPrebuilt roomCode="aue-gnov-bkt" />
+    <div>
+      <p>You are a {roleName}</p>
+      {roleName === 'judge' && <button>Score</button>}
+      {roleName === 'speaker' && (
+        <button onClick={() => hmsActions.setLocalAudioEnabled(true)}>
+          Speak
+        </button>
+      )}
+      {roleName === 'moderator' && <p>Moderator panel</p>}
     </div>
   );
 }
 
-export default App;
+function JoinRoom() {
+  const hmsActions = useHMSActions();
+  const isConnected = useHMSStore(selectIsConnected);
+  const [role, setRole] = useState('audience');
+
+  const join = async () => {
+    const { data } = await axios.post('/api/create-room', { role });
+    await hmsActions.join({
+      authToken: data.token,
+      userName: 'guest',
+      settings: { isAudioMuted: role !== 'speaker' },
+    });
+  };
+
+  if (isConnected) {
+    return <RoleControls />;
+  }
+
+  return (
+    <div className="join-panel">
+      <select value={role} onChange={(e) => setRole(e.target.value)}>
+        <option value="judge">Judge</option>
+        <option value="speaker">Speaker</option>
+        <option value="moderator">Moderator</option>
+        <option value="audience">Audience</option>
+      </select>
+      <button onClick={join}>Join Room</button>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <HMSRoomProvider>
+      <JoinRoom />
+    </HMSRoomProvider>
+  );
+}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders join room button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const button = screen.getByRole('button', { name: /join room/i });
+  expect(button).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add instructions for creating rooms and roles with 100ms
- setup backend Express server for Management API and JWT generation
- swap prebuilt in React client for SDK-based join UI
- add Join Room test

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843ce560cb8832bbee40f7ab822f017