### PR TITLE
Add backend token service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+HMS_ACCESS_KEY=your_access_key
+HMS_APP_SECRET=your_app_secret
+HMS_MANAGEMENT_TOKEN=your_management_token
+HMS_TEMPLATE_ID=template_id
+HMS_ROLE=host
+PORT=3001

--- a/package.json
+++ b/package.json
@@ -13,13 +13,18 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "dotenv": "^16.3.1",
+    "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^3.3.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server.js
+++ b/server.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+const app = express();
+app.use(express.json());
+
+const HMS_BASE = 'https://api.100ms.live/v2';
+const { HMS_TEMPLATE_ID, HMS_MANAGEMENT_TOKEN, HMS_ACCESS_KEY, HMS_APP_SECRET, HMS_ROLE } = process.env;
+
+async function findRoom(name) {
+  const res = await fetch(`${HMS_BASE}/rooms?limit=1&name=${name}`, {
+    headers: { Authorization: `Bearer ${HMS_MANAGEMENT_TOKEN}` }
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.data && data.data.length > 0 ? data.data[0] : null;
+}
+
+async function createRoom(name) {
+  const res = await fetch(`${HMS_BASE}/rooms`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${HMS_MANAGEMENT_TOKEN}`
+    },
+    body: JSON.stringify({ name, template_id: HMS_TEMPLATE_ID })
+  });
+  if (!res.ok) throw new Error('failed to create room');
+  return await res.json();
+}
+
+app.post('/api/join', async (req, res) => {
+  const { roomName, userName } = req.body;
+  if (!roomName || !userName) {
+    return res.status(400).json({ error: 'roomName and userName required' });
+  }
+  try {
+    let room = await findRoom(roomName);
+    if (!room) {
+      room = await createRoom(roomName);
+    }
+    const payload = {
+      access_key: HMS_ACCESS_KEY,
+      room_id: room.id,
+      user_id: userName,
+      role: HMS_ROLE || 'host',
+      type: 'app',
+      version: 2
+    };
+    const token = jwt.sign(payload, HMS_APP_SECRET, { expiresIn: '1h' });
+    res.json({ token, roomId: room.id });
+  } catch (e) {
+    res.status(500).json({ error: 'unable to generate token' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on ${PORT}`));

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,43 @@
 import './App.css';
 import { HMSPrebuilt } from '@100mslive/roomkit-react';
+import { useState } from 'react';
+
 function App() {
+  const [token, setToken] = useState(null);
+  const [roomName, setRoomName] = useState('');
+  const [userName, setUserName] = useState('');
+
+  const handleJoin = async () => {
+    const res = await fetch('/api/join', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ roomName, userName }),
+    });
+    const data = await res.json();
+    setToken(data.token);
+  };
+
+  if (token) {
+    return (
+      <div style={{ height: '100vh' }}>
+        <HMSPrebuilt authToken={token} />
+      </div>
+    );
+  }
+
   return (
-    <div style={{ height: "100vh" }}>
-      <HMSPrebuilt roomCode="aue-gnov-bkt" />
+    <div className="join-container">
+      <input
+        value={roomName}
+        onChange={(e) => setRoomName(e.target.value)}
+        placeholder="Room Name"
+      />
+      <input
+        value={userName}
+        onChange={(e) => setUserName(e.target.value)}
+        placeholder="Your Name"
+      />
+      <button onClick={handleJoin}>Join</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add form for dynamic room join instead of hardcoded room code
- create Express backend to create rooms and generate auth tokens using 100ms Management API
- document environment variables
- add server dependencies and npm script

## Testing
- `npm test --silent --no-watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843d839ecf4832b812ae39148dad533